### PR TITLE
Implemented LRU Cache Data Structure

### DIFF
--- a/src/data-structures/index.js
+++ b/src/data-structures/index.js
@@ -6,6 +6,7 @@ const LinkedList = require('./linked_list');
 const Queue = require('./queue');
 const Stack = require('./stack');
 const Trie = require('./trie');
+const LRUCache = require('./lru_cache');
 
 module.exports = {
   DoublyLinkedList,
@@ -15,5 +16,6 @@ module.exports = {
   LinkedList,
   Queue,
   Stack,
-  Trie
+  Trie,
+  LRUCache
 };

--- a/src/data-structures/lru_cache.js
+++ b/src/data-structures/lru_cache.js
@@ -37,10 +37,6 @@ class LRUCache {
       return false;
     }
 
-    if (Object.keys(this._omap).includes(k)) {
-      return false;
-    }
-
     while (this._size + osize > this._max) {
       const dkey = this._oqueue.pop().value;
       this._size -= this._omap[dkey]._size;

--- a/src/data-structures/lru_cache.js
+++ b/src/data-structures/lru_cache.js
@@ -1,0 +1,88 @@
+const DoublyLinkedList = require('./doubly_linked_list');
+
+/**
+ * Class for LRUCache
+ */
+class LRUCache {
+  /**
+     *
+     * @param {Number} max max size of the cache, in units determined by sizef
+     * @param {Function} [sizef = () => 1] function to determine the size of an object.
+     *   By default, all objects are size 1
+     */
+  constructor(max = Infinity, sizef = () => 1) {
+    this._max = max;
+    this._size = 0;
+    this._sizef = sizef;
+
+    this._oqueue = new DoublyLinkedList();
+    this._omap = {};
+  }
+
+  /** insert a key/value pair into the cache
+     *  new entries are always prioritized over old entries
+     *  entries too large to fit in the entire cache
+     *    (even alone) are rejected and undefined is returned
+     *
+     * @param {*} k
+     * @param {*} v
+     * @return {Boolean} true if insert was successful, false if entry was:
+     *   * too large
+     *   * a duplicate key
+     */
+  insert(k, v) {
+    const osize = this._sizef(v);
+    if (osize > this._max) {
+      return false;
+    }
+
+    if (Object.keys(this._omap).includes(k)) {
+      return false;
+    }
+
+    while (this._size + osize > this._max) {
+      const dkey = this._oqueue.pop().value;
+      this._size -= this._omap[dkey]._size;
+      delete this._omap[dkey];
+    }
+    this._oqueue.push(k);
+    this._omap[k] = {
+      _size: osize,
+      val: v,
+      node: this._oqueue.head
+    };
+    this._size += osize;
+    return true;
+  }
+
+  /**
+     * get an item from the cache
+     * @param {*} k the key whose value is desired
+     * @return {*} the value of the desired key, or undefined if the key was
+     *   not in the cache
+     */
+  get(k) {
+    const v = this._omap[k];
+    if (v === undefined) {
+      return undefined;
+    }
+    this._oqueue.deleteNode(v.node);
+    this._oqueue.push(k);
+    v.node = this._oqueue.head;
+    return v.val;
+  }
+
+  /**
+   * get the current size of the cache
+   */
+  get size() {
+    return this._size;
+  }
+
+  toString() {
+    return `${JSON.stringify(this._omap)}\n${this._oqueue.toString()}`;
+  }
+}
+
+
+module.exports = LRUCache;

--- a/src/data-structures/lru_cache.js
+++ b/src/data-structures/lru_cache.js
@@ -31,6 +31,7 @@ class LRUCache {
      *   * a duplicate key
      */
   insert(k, v) {
+    k = `${k}`;
     const osize = this._sizef(v);
     if (osize > this._max) {
       return false;

--- a/test/data-structures/testLRUCache.js
+++ b/test/data-structures/testLRUCache.js
@@ -10,6 +10,7 @@ describe('LRU Cache', () => {
 
   it('should increase in size when an item is inserted', () => {
     const cache = new LRUCache(1);
+    assert.equal(cache.size, 0);
     cache.insert('a', 'oboe');
     assert.equal(cache.size, 1);
   });

--- a/test/data-structures/testLRUCache.js
+++ b/test/data-structures/testLRUCache.js
@@ -33,11 +33,11 @@ describe('LRU Cache', () => {
     assert.equal(cache.get('a'), undefined);
   });
 
-  it('should not insert key/value pairs whose key is already in the cache (no duplicate keys)', () => {
+  it('should overwrite key/value pairs whose key is already in the cache (no duplicate keys)', () => {
     const cache = new LRUCache(2);
     cache.insert('a', 'oboe');
     cache.insert('a', 'trumpet');
-    assert.equal(cache.get('a'), 'oboe');
+    assert.equal(cache.get('a'), 'trumpet');
   });
 
   it('should return undefined when attempting to access a key which is not within the cache', () => {
@@ -59,7 +59,7 @@ describe('LRU Cache', () => {
     const cache = new LRUCache(5, i => i.length);
     cache.insert('1', 'ab');
     cache.insert(1, 'cd');
-    assert.equal(cache.get('1'), 'ab');
-    assert.equal(cache.get(1), 'ab');
+    assert.equal(cache.get('1'), 'cd');
+    assert.equal(cache.get(1), 'cd');
   });
 });

--- a/test/data-structures/testLRUCache.js
+++ b/test/data-structures/testLRUCache.js
@@ -54,4 +54,12 @@ describe('LRU Cache', () => {
     assert.equal(cache.get('2'), undefined);
     assert.equal(cache.get('3'), 'efghi');
   });
+
+  it('should consider keys as strings to avoid type confusion (to be consistent with JS object key equality)', () => {
+    const cache = new LRUCache(5, i => i.length);
+    cache.insert('1', 'ab');
+    cache.insert(1, 'cd');
+    assert.equal(cache.get('1'), 'ab');
+    assert.equal(cache.get(1), 'ab');
+  });
 });

--- a/test/data-structures/testLRUCache.js
+++ b/test/data-structures/testLRUCache.js
@@ -1,0 +1,57 @@
+/* eslint-env mocha */
+const LRUCache = require('../../src').datastructures.LRUCache;
+const assert = require('assert');
+
+describe('LRU Cache', () => {
+  it('should be empty when initialized', () => {
+    const cache = new LRUCache(1);
+    assert.equal(cache.size, 0);
+  });
+
+  it('should increase in size when an item is inserted', () => {
+    const cache = new LRUCache(1);
+    cache.insert('a', 'oboe');
+    assert.equal(cache.size, 1);
+  });
+
+  it('should store items inserted in key-value pairs accessible by key', () => {
+    const cache = new LRUCache(1);
+    cache.insert('a', 'oboe');
+    assert.equal(cache.get('a'), 'oboe');
+  });
+
+  it('should drop the least recently used item if the inserted item puts the cache over capacity', () => {
+    const cache = new LRUCache(1);
+    cache.insert('a', 'oboe');
+    cache.insert('b', 'clarinet');
+    assert.equal(cache.get('a'), undefined);
+  });
+
+  it('should not insert objects whose size exceeds the cache maximum', () => {
+    const cache = new LRUCache(0);
+    cache.insert('a', 'oboe');
+    assert.equal(cache.get('a'), undefined);
+  });
+
+  it('should not insert key/value pairs whose key is already in the cache (no duplicate keys)', () => {
+    const cache = new LRUCache(2);
+    cache.insert('a', 'oboe');
+    cache.insert('a', 'trumpet');
+    assert.equal(cache.get('a'), 'oboe');
+  });
+
+  it('should return undefined when attempting to access a key which is not within the cache', () => {
+    const cache = new LRUCache(2);
+    assert.equal(cache.get('b'), undefined);
+  });
+
+  it('should drop as many items as necessary (in order of LRU) to fit the item being inserted', () => {
+    const cache = new LRUCache(5, i => i.length);
+    cache.insert('1', 'ab');
+    cache.insert('2', 'cd');
+    cache.insert('3', 'efghi');
+    assert.equal(cache.get('1'), undefined);
+    assert.equal(cache.get('2'), undefined);
+    assert.equal(cache.get('3'), 'efghi');
+  });
+});


### PR DESCRIPTION
<!--  Use the following format for your Pull Request title:

    BUG FIX
    {Issue ID|BUG FIX}: {Description of change}

    OTHERS
    {Whatever}: {Description of change} -->

## Description of new feature, or changes
<!-- What exactly does this PR do? -->
Introduces a class (LRUCache) which implements a least-recently-used cache data structure. LRU cache is most commonly known for its popularity in operating systems applications for managing system memory caches. 

This implementation accepts entries as key-value pairs. If a new entry would exceed the cache's configured maximum size, the least recently retrieved items are removed and destroyed from memory until there is enough room for the new one.

By default, items are considered to have size 1. However, you can specify a custom size function for how big to consider items. For example, if you are storing strings in your cache with a maximum limit of 20, you could specify that the cache should consider the string's length as its size, you would effectively have a cache with a maximum size of 20 bytes.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #12" -->
Implements #17 

## People to notify
<!-- Please @mention relevant people here: -->
@manrajgrover 
